### PR TITLE
Various (many) changes in vocabs

### DIFF
--- a/alignmentType.ttl
+++ b/alignmentType.ttl
@@ -13,6 +13,7 @@
 alignment: a skos:ConceptScheme ;
     dc:description "Describes the types of relationships between a learning resource and an AlighmentObject."@en-US ;
     dc:title "LRMI Alignment Type Vocabulary"@en-US ;
+    dc:creator "LRMI Task Group (DCMI)"@en-US ; 
     dcterms:created "2015-01-21"^^xsd:date ;
     dcterms:license <http://creativecommons.org/licenses/by/4.0/> ;
     adms:status <http://purl.org/dcx/lrmi-vocabs/docStatus/draft> .    

--- a/alignmentType.ttl
+++ b/alignmentType.ttl
@@ -7,71 +7,106 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 @prefix alignment: <http://purl.org/dcx/lrmi-vocabs/alignmentType/> .
 
 alignment: a skos:ConceptScheme ;
-    dc:description "Describes the types of relationships between a learning resource and an AlighmentObject."@en ;
-    dc:title "LRMI Alignment Type Vocabulary"@en ;
+    dc:description """Describes the types of relationships between a learning resource and 
+        an AlighmentObject."""@en-US ;
+    dc:title "LRMI Alignment Type Vocabulary"@en-US ;
     dcterms:created "2015-01-21"^^xsd:date ;
     dcterms:license <http://creativecommons.org/licenses/by/4.0/> ;
     adms:status <http://purl.org/dcx/lrmi-vocabs/docStatus/draft> .    
 
 alignment:assesses: a skos:Concept ;
+    skos:prefLabel "assesses"@en-US ;
+    skosxl:preflabel alignment:label-assesses ;    
+    skos:definition """The origin of the association may be used to assess the destination 
+        of the association."""@en-US ;
     skos:inScheme alignment: ;
-    skos:prefLabel "assesses"@en ;
-    skosxl:preflabel alignment:label-assesses . 
+    vs:term_status "unstable" .
 
 alignment:teaches a skos:Concept ;
+    skos:prefLabel "teaches"@en-US ;
+    skosxl:preflabel alignment:label-teaches ;    
+    skos:definition """The resource or method at the origin of the association may be used 
+        to teach the competency at the destination of the association."""@en-US ;
     skos:inScheme alignment: ;
-    skos:prefLabel "teaches"@en ;
-    skosxl:preflabel alignment:label-teaches .         
+    vs:term_status "unstable" .            
 
 alignment:requires a skos:Concept ;
-    skos:inScheme alignment: ;
-    skos:prefLabel "requires"@en ;
-    skosxl:preflabel alignment:label-requires .    
+    skos:prefLabel "requires"@en-US ;
+    skosxl:preflabel alignment:label-requires ;    
+    skos:definition """The origin of the association requires the destination of the association 
+        to support its function, delivery, or coherence."""@en-US ;
+    skos:inScheme alignment: ;    
+    vs:term_status "unstable" .    
+   
 
 alignment:textComplexity a skos:Concept ;
-    skos:inScheme alignment: ;
-    skos:prefLabel "text complexity"@en ;
-    skosxl:preflabel alignment:label-textComplexity .    
+    skos:prefLabel "text complexity"@en-US ;
+    skosxl:preflabel alignment:label-textComplexity ;    
+    skos:definition """The destination of the association defines a level or range, measuring 
+        the ease in which text can be read and understood, for text used within the resource at 
+        the origin of the association."""@en-US ;
+    skos:inScheme alignment: ;     
+    vs:term_status "unstable" .
 
 alignment:readingLevel a skos:Concept ;
-    skos:inScheme alignment: ;
-    skos:prefLabel "reading level"@en ;
-    skosxl:preflabel alignment:label-readingLevel .    
+    skos:prefLabel "reading level"@en-US ;
+    skosxl:preflabel alignment:label-readingLevel ;    
+    skos:definition """The destination of the association defines a level or range of ability 
+        expected for a person using the resource at the origin of the association."""@en-US ;
+    skos:inScheme alignment: ;     
+    vs:term_status "unstable" .
 
 alignment:educationalSubject a skos:Concept ;
+    skos:prefLabel "educational subject"@en-US ;
+    skosxl:preflabel alignment:label-educationalSubject ;    
+    skos:definition """The destination of the association defines a topic or subject from a 
+        controlled vocabulary."""@en-US ;
     skos:inScheme alignment: ;
-    skos:prefLabel "educational subject"@en ;
-    skosxl:preflabel alignment:label-educationalSubject .     
+    vs:term_status "unstable" .  
+    
+alignment:cognitiveComplexity: a skos:Concept ;
+    skos:prefLabel "cognitive complexity"@en-US ;
+    skosxl:preflabel alignment:label-cognitiveComplexity ;    
+    skos:definition """@@@."""@en-US ;
+    skos:inScheme alignment: ;
+    vs:term_status "unstable" .      
 
 alignment:educationalLevel a skos:Concept ;
+    skos:prefLabel "educational level"@en-US ;
+    skosxl:preflabel alignment:label-educationalLevel ;    
+    skos:definition """he destination of the association defines an education level from a 
+        controlled vocabulary."""@en-US ;
     skos:inScheme alignment: ;
-    skos:prefLabel "educational level"@en ;
-    skosxl:preflabel alignment:label-educationalLevel .    
+    vs:term_status "unstable" .         
     
 #============================= 
 # EXTENDED LABELS
 #=============================    
     
 alignment:label-assesses a skosxl:label ;
-    skosxl:literalForm "assesses"@en . 
+    skosxl:literalForm "assesses"@en-US .
+    
+alignment:label-cognitiveComplexity a skosxl:label ;
+    skosxl:literalForm "cognitive complexity"@en-US .     
     
 alignment:label-teaches a skosxl:label ;
-    skosxl:literalForm "teaches"@en .   
+    skosxl:literalForm "teaches"@en-US .   
         
 alignment:label-requires a skosxl:label ;
-    skosxl:literalForm "requires"@en .   
+    skosxl:literalForm "requires"@en-US .   
         
 alignment:label-textComplexity a skosxl:label ;
-    skosxl:literalForm "text complexity"@en .
+    skosxl:literalForm "text complexity"@en-US .
         
 alignment:label-readingLevel a skosxl:label ;
-    skosxl:literalForm "reading level"@en .  
+    skosxl:literalForm "reading level"@en-US .  
         
 alignment:label-educationalSubject a skosxl:label ;
-    skosxl:literalForm "educational subject"@en .
+    skosxl:literalForm "educational subject"@en-US .
         
 alignment:label-educationalLevel a skosxl:label ;
-    skosxl:literalForm "educational level"@en .                             
+    skosxl:literalForm "educational level"@en-US .                             

--- a/alignmentType.ttl
+++ b/alignmentType.ttl
@@ -11,8 +11,7 @@
 @prefix alignment: <http://purl.org/dcx/lrmi-vocabs/alignmentType/> .
 
 alignment: a skos:ConceptScheme ;
-    dc:description """Describes the types of relationships between a learning resource and 
-        an AlighmentObject."""@en-US ;
+    dc:description "Describes the types of relationships between a learning resource and an AlighmentObject."@en-US ;
     dc:title "LRMI Alignment Type Vocabulary"@en-US ;
     dcterms:created "2015-01-21"^^xsd:date ;
     dcterms:license <http://creativecommons.org/licenses/by/4.0/> ;
@@ -21,65 +20,66 @@ alignment: a skos:ConceptScheme ;
 alignment:assesses: a skos:Concept ;
     skos:prefLabel "assesses"@en-US ;
     skosxl:preflabel alignment:label-assesses ;    
-    skos:definition """The origin of the association may be used to assess the destination 
-        of the association."""@en-US ;
+    skos:definition "The learning resource being described may be used to assess the competency being referenced."@en-US ;
+    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#Assesses."@en-US ;
     skos:inScheme alignment: ;
     vs:term_status "unstable" .
 
 alignment:teaches a skos:Concept ;
     skos:prefLabel "teaches"@en-US ;
     skosxl:preflabel alignment:label-teaches ;    
-    skos:definition """The resource or method at the origin of the association may be used 
-        to teach the competency at the destination of the association."""@en-US ;
+    skos:definition "The learning resource being described may be used to teach the competency being referenced."@en-US ;
+    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#Teaches."@en-US ;   
     skos:inScheme alignment: ;
     vs:term_status "unstable" .            
 
 alignment:requires a skos:Concept ;
     skos:prefLabel "requires"@en-US ;
     skosxl:preflabel alignment:label-requires ;    
-    skos:definition """The origin of the association requires the destination of the association 
-        to support its function, delivery, or coherence."""@en-US ;
+    skos:definition "The learning resouce being described requires the competency being referenced to support its function, delivery, or coherence."@en-US ;
     skos:inScheme alignment: ;    
     vs:term_status "unstable" .    
    
-
 alignment:textComplexity a skos:Concept ;
     skos:prefLabel "text complexity"@en-US ;
     skosxl:preflabel alignment:label-textComplexity ;    
-    skos:definition """The destination of the association defines a level or range, measuring 
-        the ease in which text can be read and understood, for text used within the resource at 
-        the origin of the association."""@en-US ;
+    skos:definition "The resource being referenced defines a level or range that measures the ease with which text embodied in the learning resource being described can be read and understood."@en-US ;
+    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#TextComplexity."@en-US ;     
+    skos:broader alignment:cognitiveComplexity ;
     skos:inScheme alignment: ;     
     vs:term_status "unstable" .
 
 alignment:readingLevel a skos:Concept ;
     skos:prefLabel "reading level"@en-US ;
     skosxl:preflabel alignment:label-readingLevel ;    
-    skos:definition """The destination of the association defines a level or range of ability 
-        expected for a person using the resource at the origin of the association."""@en-US ;
+    skos:definition "The framework being referenced defines a level or range of reading ability expected for a person using the learning resource being described."@en-US ;
+    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#ReadingLevel."@en-US ;      
     skos:inScheme alignment: ;     
     vs:term_status "unstable" .
 
 alignment:educationalSubject a skos:Concept ;
     skos:prefLabel "educational subject"@en-US ;
     skosxl:preflabel alignment:label-educationalSubject ;    
-    skos:definition """The destination of the association defines a topic or subject from a 
-        controlled vocabulary."""@en-US ;
+    skos:definition "The resource being referenced defines a topic or subject of the learning resource being described."@en-US ;
+    skos:note "The resource being referenced is preferably a concept from a controlled vocabulary (i.e., concept scheme)."@en-US ;
+    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#EducationalSubject."@en-US ;      
     skos:inScheme alignment: ;
     vs:term_status "unstable" .  
     
 alignment:cognitiveComplexity: a skos:Concept ;
     skos:prefLabel "cognitive complexity"@en-US ;
     skosxl:preflabel alignment:label-cognitiveComplexity ;    
-    skos:definition """@@@."""@en-US ;
+    skos:definition "The resource being referenced defines a level or range that measures the cognitive complexity of the learning resource being described."@en-US ;
+    skos:narrower alignment:textComplexity ;    
     skos:inScheme alignment: ;
     vs:term_status "unstable" .      
 
 alignment:educationalLevel a skos:Concept ;
     skos:prefLabel "educational level"@en-US ;
     skosxl:preflabel alignment:label-educationalLevel ;    
-    skos:definition """he destination of the association defines an education level from a 
-        controlled vocabulary."""@en-US ;
+    skos:definition "The resource being referenced defines an education level for which the resource being described is intended or useful."@en-US ;
+    skos:note "The resource being referenced is preferably a concept from a controlled vocabulary (i.e., concept scheme)."@en-US ;
+    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#EducationalLevel."@en-US ;         
     skos:inScheme alignment: ;
     vs:term_status "unstable" .         
     

--- a/educationalUse.ttl
+++ b/educationalUse.ttl
@@ -11,6 +11,7 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 
 # Defines a set of top-level concepts of Educational Use
+# TESTING CHANGES USING GITHUB FOR MAC
 
 edUse: a skos:ConceptScheme ;
     dc:title "LRMI Educational Use vocabulary" ;

--- a/educationalUse.ttl
+++ b/educationalUse.ttl
@@ -24,12 +24,8 @@ edUse:instruction a skos:Concept ;
     skos:definition """Primary purpose of the resource is to support the instructional 
         process, student learning, or to provide information about the curriculum."""@en ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/edUse/> ;
-    skos:note """Based on the CEDS Learning Resource Educational Use term 
-        \"Curriculum/Instruction\" at https://ceds.ed.gov/element/001002."""@en ;
+    dcterms:source <https://ceds.ed.gov/element/001002> ;
     vs:term_status "unstable" .
-    
-edUse:label-instruction a skosxl:label ;
-    skosxl:literalForm "instruction"@en .
     
 edUse:assessment a skos:Concept ;
     skos:prefLabel "assessment"@en ;
@@ -37,12 +33,8 @@ edUse:assessment a skos:Concept ;
     skos:definition """Primary purpose of the resource is to evaluate learning, either 
         before or after instruction occurs."""@en ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/edUse/> ;
-    skos:note """Based on the CEDS Learning Resource Educational Use term \"Assessment\" at 
-        https://ceds.ed.gov/element/001002."""@en ;
-    vs:term_status "unstable" .
-    
-edUse:label-assessment a skosxl:label ;
-    skosxl:literalForm "assessment"@en .    
+    dcterms:source <https://ceds.ed.gov/element/001002> ;
+    vs:term_status "unstable" .   
 
 edUse:professionalDevelopment a skos:Concept ;
     skos:prefLabel "professional development"@en ;
@@ -50,9 +42,16 @@ edUse:professionalDevelopment a skos:Concept ;
     skos:definition """Primary purpose of the resource is to provide instruction for a teacher 
         or other education professional."""@en ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/edUse/> ;
-    skos:note """Based on the CEDS Learning Resource Educational Use term \"Professional 
-        Development\" at https://ceds.ed.gov/element/001002."""@en ;  
+    dcterms:source <https://ceds.ed.gov/element/001002> ;  
     vs:term_status "unstable" .
+    
+# EXTENDED LABELS    
 
+edUse:label-instruction a skosxl:label ;
+    skosxl:literalForm "instruction"@en .
+        
+edUse:label-assessment a skosxl:label ;
+    skosxl:literalForm "assessment"@en .
+    
 edUse:label-professionalDevelopment a skosxl:label ;
     skosxl:literalForm "professional development"@en .

--- a/educationalUse.ttl
+++ b/educationalUse.ttl
@@ -45,7 +45,9 @@ edUse:professionalDevelopment a skos:Concept ;
     dcterms:source <https://ceds.ed.gov/element/001002> ;  
     vs:term_status "unstable" .
     
-# EXTENDED LABELS    
+#============================= 
+# EXTENDED LABELS
+#============================= 
 
 edUse:label-instruction a skosxl:label ;
     skosxl:literalForm "instruction"@en .

--- a/educationalUse.ttl
+++ b/educationalUse.ttl
@@ -14,33 +14,31 @@
 
 edUse: a skos:ConceptScheme ;
     dc:title "LRMI Educational Use vocabulary" ;
+    dc:creator "LRMI Task Group (DCMI)"@en-US ;
     dcterms:created "2015-01-21"^^xsd:date ;
     dcterms:license <http://creativecommons.org/licenses/by/4.0/> ;
     adms:status <http://purl.org/dcx/lrmi-vocabs/docStatus/draft> .      
 
 edUse:instruction a skos:Concept ;
-    skos:prefLabel "instruction"@en ;
+    skos:prefLabel "instruction"@en-US ;
     skosxl:prefLabel edUse:label-instruction ;
-    skos:definition """Primary purpose of the resource is to support the instructional 
-        process, student learning, or to provide information about the curriculum."""@en ;
+    skos:definition "Primary purpose of the resource is to support the instructional process, student learning, or to provide information about the curriculum."@en-US ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/edUse/> ;
     dcterms:source <https://ceds.ed.gov/element/001002> ;
     vs:term_status "unstable" .
     
 edUse:assessment a skos:Concept ;
-    skos:prefLabel "assessment"@en ;
+    skos:prefLabel "assessment"@en-US ;
     skosxl:prefLabel edUse:label-assessment ;
-    skos:definition """Primary purpose of the resource is to evaluate learning, either 
-        before or after instruction occurs."""@en ;
+    skos:definition "Primary purpose of the resource is to evaluate learning, either before or after instruction occurs."@en-US ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/edUse/> ;
     dcterms:source <https://ceds.ed.gov/element/001002> ;
     vs:term_status "unstable" .   
 
 edUse:professionalDevelopment a skos:Concept ;
-    skos:prefLabel "professional development"@en ;
+    skos:prefLabel "professional development"@en-US ;
     skosxl:prefLabel edUse:label-professionalDevelopment ;
-    skos:definition """Primary purpose of the resource is to provide instruction for a teacher 
-        or other education professional."""@en ;
+    skos:definition "Primary purpose of the resource is to provide instruction for a teacher or other education professional."@en-US ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/edUse/> ;
     dcterms:source <https://ceds.ed.gov/element/001002> ;  
     vs:term_status "unstable" .
@@ -50,10 +48,10 @@ edUse:professionalDevelopment a skos:Concept ;
 #============================= 
 
 edUse:label-instruction a skosxl:label ;
-    skosxl:literalForm "instruction"@en .
+    skosxl:literalForm "instruction"@en-US .
         
 edUse:label-assessment a skosxl:label ;
-    skosxl:literalForm "assessment"@en .
+    skosxl:literalForm "assessment"@en-US .
     
 edUse:label-professionalDevelopment a skosxl:label ;
-    skosxl:literalForm "professional development"@en .
+    skosxl:literalForm "professional development"@en-US .

--- a/educationalUse.ttl
+++ b/educationalUse.ttl
@@ -11,7 +11,6 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 
 # Defines a set of top-level concepts of Educational Use
-# TESTING CHANGES USING GITHUB FOR MAC
 
 edUse: a skos:ConceptScheme ;
     dc:title "LRMI Educational Use vocabulary" ;

--- a/interactivityType.ttl
+++ b/interactivityType.ttl
@@ -8,54 +8,49 @@
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix interactivity: <http://purl.org/dcx/lrmi-vocabs/interactivityType/> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
 
 interactivity: a skos:ConceptScheme ;
-    dc:title "Interactivity Type Vocabulary"@en ;
-    dcterms:description """Concepts defining the predominate interactivity mode of the 
-        learning resource being described."""@en ;
-    dcterms:source """Based on the IEEE Learning Object Metadata standard (IEEE/LOM - IEEE 
-        1484.12.1-202)."""@n ;        
+    dc:title "Interactivity Type Vocabulary"@en-US ;
+    dc:creator "LRMI Task Group (DCMI)"@en-US ;    
+    dcterms:description "Concepts defining the predominate interactivity mode of the learning resource being described."@en-US ;
+    dcterms:source "Based on the IEEE Learning Object Metadata standard (IEEE/LOM - IEEE 1484.12.1-202)."@en-US ;
+    adms:status <http://purl.org/dcx/lrmi-vocabs/docStatus/draft> ;        
     dcterms:license <http://creativecommons.org/licenses/by/4.0/> .
 
 interactivity:active a skos:Concept ;
-    skos:prefLabel "active"@en ;
+    skos:prefLabel "active"@en-US ;
     skosxl:preflabel interactivity:label-active ;   
-    skos:definition """\"Existing in action, working, effective, having practical operation 
-        or result\" (OED)."""@en ;
-    dcterms:source """Based on the IEEE Learning Object Metadata standard (IEEE 
-        1484.12.1-202 (LOMv1.0))."""@n ;
-    vs:term_status "unstable" ;
-    skos:inScheme interactivity: .
+    skos:definition "\"Existing in action, working, effective, having practical operation or result\" (OED)."@en-US ;
+    dcterms:source "Based on the IEEE Learning Object Metadata standard (IEEE 1484.12.1-202 (LOMv1.0))."@en-US ;
+    skos:inScheme interactivity: ;
+    vs:term_status "unstable" .
     
 interactivity:expositive a skos:Concept ;
-    skos:prefLabel "expositive"@en ;
+    skos:prefLabel "expositive"@en-US ;
     skosxl:preflabel interactivity:label-expositive ;  
-    skos:definition """\"Tending to set forth or describe in detail; descriptive; serving 
-        to explain\" (OED)."""@en ;
-    dcterms:source """Based on the IEEE Learning Object Metadata standard (IEEE 
-        1484.12.1-202 (LOMv1.0))."""@n ;
-    vs:term_status "unstable" ;
-    skos:inScheme interactivity: .
+    skos:definition "\"Tending to set forth or describe in detail; descriptive; serving to explain\" (OED)."@en-US ;
+    dcterms:source "Based on the IEEE Learning Object Metadata standard (IEEE 1484.12.1-202 (LOMv1.0))."@en-US ;
+    skos:inScheme interactivity: ;    
+    vs:term_status "unstable" .
     
 interactivity:mixed a skos:Concept ;
-    skos:prefLabel "mixed"@en ;
+    skos:prefLabel "mixed"@en-US ;
     skosxl:preflabel interactivity:label-mixed ;
-    skos:definition """\"Consisting of different or dissimilar elements or qualities; not 
-        of one kind; not pure or simple; composite\" (OED)."""@en ;
-    dcterms:source """Based on IEEE Learning Object Metadata standard (IEEE 
-        1484.12.1-202 (LOMv1.0))."""@n ;
-    vs:term_status "unstable" ;
-    skos:inScheme interactivity: . 
+    skos:definition "\"Consisting of different or dissimilar elements or qualities; not of one kind; not pure or simple; composite\" (OED)."@en-US ;
+    dcterms:source "Based on IEEE Learning Object Metadata standard (IEEE 1484.12.1-202 (LOMv1.0))."@en-US ;
+    skos:inScheme interactivity: ;    
+    vs:term_status "unstable" .
     
 #============================= 
 # EXTENDED LABELS
 #=============================     
     
 interactivity:label-active a skosxl:label ;
-    skosxl:literalForm "active"@en . 
+    skosxl:literalForm "active"@en-US . 
     
 interactivity:label-expositive a skosxl:label ;
-    skosxl:literalForm "expositive"@en .
+    skosxl:literalForm "expositive"@en-US .
     
 interactivity:label-mixed a skosxl:label ;
-    skosxl:literalForm "mixed"@en . 
+    skosxl:literalForm "mixed"@en-US . 

--- a/learningResourceType.ttl
+++ b/learningResourceType.ttl
@@ -12,161 +12,137 @@
 @prefix resourceType: <http://purl.org/dcx/lrmi-vocabs/learningResourceType/> .
 
 resourceType: a skos:ConceptScheme ;
-    dc:title "LRMI Learning Resource Type Vocabulary"@en ;
-    dc:description """The predominate genre, type or kind characterizing the learning 
-        resource."""@en ;
-    dc:source """Based in part on the CEDS Learning Resource Type vocabulary found at 
-        https://ceds.ed.gov/element/000928"""@en ;
+    dc:title "LRMI Learning Resource Type Vocabulary"@en-US ;
+    dc:creator "LRMI Task Group (DCMI)"@en-US ;
+    dcterms:created "2015-01-21"^^xsd:date ; 
+    dc:description "The predominate genre, type or kind characterizing the learning resource."@en-US ;
+    dc:source "Based in part on the CEDS Learning Resource Type vocabulary found at https://ceds.ed.gov/element/000928"@en-US ;
     adms:status <http://purl.org/dcx/lrmi-vocabs/docStatus/draft> .
 
 resourceType:alternateAssessment a skos:Concept ;
-    skos:prefLabel "alternate assessment"@en ;
+    skos:prefLabel "alternate assessment"@en-US ;
     skosxl:prefLabel resourceType:label-alternateAssessment ;    
-    skos:definition """An assessment that is used to evaluate the performance of students 
-        who are unable to participate in general state assessments even with 
-        accommodations."""@en ;
+    skos:definition "An assessment that is used to evaluate the performance of students who are unable to participate in general state assessments even with accommodations."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#AlternateAssessment> ;
     vs:term_status "unstable" .
     
 resourceType:assessmentItem a skos:Concept ;
-    skos:prefLabel "assessment item"@en ;
+    skos:prefLabel "assessment item"@en-US ;
     skosxl:prefLabel resourceType:label-assessmentItem ; 
-    skos:definition """A specific prompt, that defines a question or protocol for a 
-        measurable activity that triggers a response from a person used to determine 
-        whether the person has mastered a learning objective."""@en ;
+    skos:definition "A specific prompt, that defines a question or protocol for a measurable activity that triggers a response from a person used to determine whether the person has mastered a learning objective."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#AssessmentItem> ;
     vs:term_status "unstable" .
        
 resourceType:course a skos:Concept ;
-    skos:prefLabel "course"@en ;
+    skos:prefLabel "course"@en-US ;
     skosxl:prefLabel resourceType:label-course ; 
-    skos:definition """A series of units and lessons used to teach the skills and 
-        knowledge required by its curriculum."""@en ;
+    skos:definition "A series of units and lessons used to teach the skills and knowledge required by its curriculum."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#Course> ;
     vs:term_status "unstable" .
 
 resourceType:demonstration-simulation a skos:Concept ;
-    skos:prefLabel "demonstration/simulation"@en ;
+    skos:prefLabel "demonstration/simulation"@en-US ;
     skosxl:prefLabel resourceType:label-demonstration-simulation ; 
-    skos:definition "An imitation or modeling of a real-world process."@en ;
+    skos:definition "An imitation or modeling of a real-world process."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#DemonstrationSimulation> ;
     vs:term_status "unstable" .
     
 resourceType:educatorCurriculum a skos:Concept ;
-    skos:prefLabel "educator curriculum Guide"@en ;
+    skos:prefLabel "educator curriculum Guide"@en-US ;
     skosxl:prefLabel resourceType:label-educatorCurriculum ;
-    skos:definition """A document that defines what concepts should be taught 
-        and/or how a concept should be taught effectively."""@en ;
+    skos:definition "A document that defines what concepts should be taught and/or how a concept should be taught effectively."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#EducatorCurriculumGuide> ;
     vs:term_status "unstable" .
     
 resourceType:formativeAssessment a skos:Concept ;
-    skos:prefLabel "formative sssessment"@en ;
+    skos:prefLabel "formative sssessment"@en-US ;
     skosxl:prefLabel resourceType:label-formativeAssessment ;
-    skos:definition """A process used by teachers and students during instruction 
-        that provides feedback to adjust ongoing teaching and learning to improve 
-        students' achievement of intended instructional outcomes. (CCSSO FAST 
-        SCASS, 2006)"""@en ;
+    skos:definition "A process used by teachers and students during instruction that provides feedback to adjust ongoing teaching and learning to improve students' achievement of intended instructional outcomes. (CCSSO FAST SCASS, 2006)"@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#FormativeAssessment> ;
     vs:term_status "unstable" .
 
 resourceType:images-visuals a skos:Concept ;
-    skos:prefLabel "images/visuals"@en ;
+    skos:prefLabel "images/visuals"@en-US ;
     skosxl:prefLabel resourceType:label-images-visuals ;
-    skos:definition """Visual media, including but not limited to pictures, graphics, 
-        diagrams, figures, illustrations, charts, and maps."""@en ;
+    skos:definition "Visual media, including but not limited to pictures, graphics, diagrams, figures, illustrations, charts, and maps."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#ImagesVisuals> ;
     vs:term_status "unstable" .
     
 resourceType:interim-summativeAssessment a skos:Concept ;
-    skos:prefLabel "interim/summative assessment"@en ;
+    skos:prefLabel "interim/summative assessment"@en-US ;
     skosxl:prefLabel resourceType:label-interim-summativeAssessment ;
-    skos:definition """An assessment instrument used to evaluate student learning 
-        at the end of an instructional unit by comparing it against some standard 
-        or benchmark. A learning resource of this typemay be an \"assessment form,\" 
-        i.e. one instance of the assessment instrument that can equate scores with 
-        another instance of the same assessment."""@en ;
+    skos:definition "An assessment instrument used to evaluate student learning at the end of an instructional unit by comparing it against some standard or benchmark. A learning resource of this typemay be an \"assessment form,\" i.e. one instance of the assessment instrument that can equate scores with another instance of the same assessment."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#InterimSummativeAssessment> ;
     vs:term_status "unstable" .    
 
 resourceType:learningActivity a skos:Concept ;
-    skos:prefLabel "learning activity"@en ;
+    skos:prefLabel "learning activity"@en-US ;
     skosxl:prefLabel resourceType:label-learningActivity ;
-    skos:definition """Activities engaged in by the learner for the purpose of 
-        acquiring certain skills, concepts, or knowledge, whether guided by an 
-        instructor or not. A Lesson may define one or more learning activities."""@en ;
+    skos:definition "Activities engaged in by the learner for the purpose of acquiring certain skills, concepts, or knowledge, whether guided by an instructor or not. A Lesson may define one or more learning activities."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#LearningActivity> ;
     vs:term_status "unstable" .    
 
 resourceType:lesson a skos:Concept ;
-    skos:prefLabel "lesson"@en ;
+    skos:prefLabel "lesson"@en-US ;
     skosxl:prefLabel resourceType:label-lesson ;
-    skos:definition """A detailed description of the course of instruction for a short 
-    period of time that is used by a teacher to guide class instruction.  A Unit 
-    contains one or more lessons."""@en ;
+    skos:definition "A detailed description of the course of instruction for a short period of time that is used by a teacher to guide class instruction.  A Unit contains one or more lessons."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#Lesson> ;
     vs:term_status "unstable" .    
 
 resourceType:primarySource a skos:Concept ;
-    skos:prefLabel "primary source"@en ;
+    skos:prefLabel "primary source"@en-US ;
     skosxl:prefLabel resourceType:label-primarySource ;
-    skos:definition """An artifact, document, recording, or other source of information 
-        that was created at the time under study and provides first-hand testimony or 
-        direct evidence concerning a topic under investigation."""@en ;
+    skos:definition "An artifact, document, recording, or other source of information that was created at the time under study and provides first-hand testimony or direct evidence concerning a topic under investigation."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#PrimarySource> ;
     vs:term_status "unstable" .         
 
 resourceType:rubricScoringGuide a skos:Concept ;
-    skos:prefLabel "rubric scoring guide"@en ;
+    skos:prefLabel "rubric scoring guide"@en-US ;
     skosxl:prefLabel resourceType:label-rubricScoringGuide ;
-    skos:definition """A document or guide that is used to delineate consistent criteria 
-        for grading."""@en ;
+    skos:definition "A document or guide that is used to delineate consistent criteria for grading."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#RubricScoringGuide> ;
     vs:term_status "unstable" .
 
 resourceType:selfAssessment a skos:Concept ;
-    skos:prefLabel "self assessment"@en ;
+    skos:prefLabel "self assessment"@en-US ;
     skosxl:prefLabel resourceType:label-selfAssessment ;
-    skos:definition """An assessment in which the user gathers information about and 
-        reflects on his or her own knowledge, skills, learning, or attitudes."""@en ;
+    skos:definition "An assessment in which the user gathers information about and reflects on his or her own knowledge, skills, learning, or attitudes."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#SelfAssessment> ;
     vs:term_status "unstable" .
 
 resourceType:text a skos:Concept ;
-    skos:prefLabel "text"@en ;
+    skos:prefLabel "text"@en-US ;
     skosxl:prefLabel resourceType:label-text ;
-    skos:definition "The body of a printed work, to include reading passages."@en ;
+    skos:definition "The body of a printed work, to include reading passages."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#Text> ;
     vs:term_status "unstable" . 
 
 resourceType:textbook a skos:Concept ;
-    skos:prefLabel "textbook"@en ;
+    skos:prefLabel "textbook"@en-US ;
     skosxl:prefLabel resourceType:label-textbook ;
-    skos:definition """A book used as a standard source of information on a particular 
-        subject."""@en ;
+    skos:definition "A book used as a standard source of information on a particular subject."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#Textbook> ;
     vs:term_status "unstable" .       
  
 resourceType:unit a skos:Concept ;
-    skos:prefLabel "unit"@en ;
+    skos:prefLabel "unit"@en-US ;
     skosxl:prefLabel resourceType:label-unit ;
-    skos:definition """A long-range plan of instruction on a particular concept; it 
-        contains multiple lessons that are related."""@en ;
+    skos:definition "A long-range plan of instruction on a particular concept; it contains multiple lessons that are related."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source <https://ceds.ed.gov/element/000928#Unit> ;
     vs:term_status "unstable" .
@@ -176,49 +152,49 @@ resourceType:unit a skos:Concept ;
 #=============================    
     
 resourceType:label-alternateAssessment a skosxl:label ;
-    skosxl:literalForm "alternate assessment"@en .
+    skosxl:literalForm "alternate assessment"@en-US .
         
 resourceType:label-assessmentItem a skosxl:label ;
-    skosxl:literalForm "assessment item"@en . 
+    skosxl:literalForm "assessment item"@en-US . 
         
 resourceType:label-course a skosxl:label ;
-    skosxl:literalForm "course"@en .
+    skosxl:literalForm "course"@en-US .
          
 resourceType:label-demonstration-simulation a skosxl:label ;
-    skosxl:literalForm "demonstration/simulation"@en .
+    skosxl:literalForm "demonstration/simulation"@en-US .
          
 resourceType:label-educatorCurriculum a skosxl:label ;
-    skosxl:literalForm "educator curriculum"@en .
+    skosxl:literalForm "educator curriculum"@en-US .
          
 resourceType:label-formativeAssessment a skosxl:label ;
-    skosxl:literalForm "formative assessment"@en .
+    skosxl:literalForm "formative assessment"@en-US .
          
 resourceType:label-images-visuals a skosxl:label ;
-    skosxl:literalForm "@@@"@en .
+    skosxl:literalForm "images/visuals"@en-US .
          
 resourceType:label-interim-summativeAssessment a skosxl:label ;
-    skosxl:literalForm "interim/summative assessment"@en .
+    skosxl:literalForm "interim/summative assessment"@en-US .
          
 resourceType:label-learningActivity a skosxl:label ;
-    skosxl:literalForm "learning activity"@en .
+    skosxl:literalForm "learning activity"@en-US .
          
 resourceType:label-lesson a skosxl:label ;
-    skosxl:literalForm "lesson"@en .
+    skosxl:literalForm "lesson"@en-US .
          
 resourceType:label-primarySource a skosxl:label ;
-    skosxl:literalForm "primary source"@en .
+    skosxl:literalForm "primary source"@en-US .
          
 resourceType:label-rubricScoringGuide a skosxl:label ;
-    skosxl:literalForm "rubric scoring guide"@en .
+    skosxl:literalForm "rubric scoring guide"@en-US .
          
 resourceType:label-selfAssessment a skosxl:label ;
-    skosxl:literalForm "self assessment"@en .
+    skosxl:literalForm "self assessment"@en-US .
          
 resourceType:label-text a skosxl:label ;
-    skosxl:literalForm "text"@en .
+    skosxl:literalForm "text"@en-US .
          
 resourceType:label-textbook a skosxl:label ;
-    skosxl:literalForm "textbook"@en .
+    skosxl:literalForm "textbook"@en-US .
          
 resourceType:label-unit a skosxl:label ;
-    skosxl:literalForm "unit"@en .      
+    skosxl:literalForm "unit"@en-US .      


### PR DESCRIPTION
Changes include:
--Addition of missing triples for status of both concept schemes and concepts (draft/unstable);
--Addition of missing definitions;
--Removal of multi-line literals (i.e., """ to ";
--Change of language from @en to @en-US.
...and various minor error correctons