### PR TITLE
Small formal fixes

### DIFF
--- a/alignmentType.ttl
+++ b/alignmentType.ttl
@@ -17,11 +17,11 @@ alignment: a skos:ConceptScheme ;
     dc:creator "LRMI Task Group (DCMI)"@en-US ; 
     dcterms:dateSubmitted "2015-01-21"^^xsd:date ;
     dcterms:license <http://creativecommons.org/licenses/by/4.0/> ;
-    adms:status bibo:draft .    
+    adms:status bibo:draft .
 
 alignment:assesses: a skos:Concept ;
     skos:prefLabel "assesses"@en-US ;
-    skosxl:preflabel alignment:label-assesses ;    
+    skosxl:preflabel alignment:label-assesses ;
     skos:definition "The learning resource being described may be used to assess the competency being referenced."@en-US ;
     dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#Assesses."@en-US ;
     skos:inScheme alignment: ;
@@ -29,56 +29,56 @@ alignment:assesses: a skos:Concept ;
     
 alignment:complexityLevel: a skos:Concept ;
     skos:prefLabel "complexity level"@en-US ;
-    skosxl:preflabel alignment:label-complexityLevel ;    
+    skosxl:preflabel alignment:label-complexityLevel ;
     skos:definition "The point in the framework being referenced defines a level or range that measures the difficulty or challenge presented by the learning resource being described."@en-US ;
-    skos:scopeNote "Example frameworks include, but are not limited to, Bloom's Taxonomy, Norm Webb Depth of Knowledge (DOK),  Biggs' SOLO taxonomy, Lexile(ª), and Quantile(ª)."@en-US ;   
+    skos:scopeNote "Example frameworks include, but are not limited to, Bloom's Taxonomy, Norm Webb Depth of Knowledge (DOK), Biggs' SOLO taxonomy, Lexile(ª), and Quantile(ª)."@en-US ;
     skos:inScheme alignment: ;
     vs:term_status "unstable" . 
 
 alignment:educationalLevel a skos:Concept ;
     skos:prefLabel "educational level"@en-US ;
-    skosxl:preflabel alignment:label-educationalLevel ;    
+    skosxl:preflabel alignment:label-educationalLevel ;
     skos:definition "The point in the framework being referenced defines an level or stage within an education system for which the resource being described is intended or useful."@en-US ;
-    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#EducationalLevel."@en-US ;         
+    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#EducationalLevel."@en-US ;
     skos:inScheme alignment: ;
     vs:term_status "unstable" . 
     
 alignment:educationalSubject a skos:Concept ;
     skos:prefLabel "educational subject"@en-US ;
-    skosxl:preflabel alignment:label-educationalSubject ;    
+    skosxl:preflabel alignment:label-educationalSubject ;
     skos:definition "The point in the framework being referenced defines the subject context of the learning resource being described."@en-US ;
-    skos:scopeNote "The educational subject identifies the educational context of the resource being described such as \"math\", \"science\", \"physics\", \"algebra\", and \"English language arts\".  To identify the particular topic(s), or aboutness, of the resource being described--e.g., \"Pythagorean theorem\", \"Abraham Lincoln\", \"Ayers Rock\"--use the schema.org/about property."@en ;
-    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#EducationalSubject."@en-US ;      
+    skos:scopeNote "The educational subject identifies the educational context of the resource being described such as \"math\", \"science\", \"physics\", \"algebra\", and \"English language arts\". To identify the particular topic(s), or aboutness, of the resource being described--e.g., \"Pythagorean theorem\", \"Abraham Lincoln\", \"Ayers Rock\"--use the schema.org/about property."@en ;
+    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#EducationalSubject."@en-US ;
     skos:inScheme alignment: ;
     vs:term_status "unstable" .
     
 alignment:prerequisite a skos:Concept ;
     skos:prefLabel "prerequisite"@en-US ;
-    skosxl:preflabel alignment:label-prerequisite ;    
-    skos:definition "The competency being referenced is a learning prerequisite to the effective outcome of  the learning resource being described."@en-US ;
-    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000715."@en-US ;         
+    skosxl:preflabel alignment:label-prerequisite ;
+    skos:definition "The competency being referenced is a learning prerequisite to the effective outcome of the learning resource being described."@en-US ;
+    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000715."@en-US ;
     skos:inScheme alignment: ;
-    vs:term_status "unstable" .        
+    vs:term_status "unstable" .
     
 alignment:readingLevel a skos:Concept ;
     skos:prefLabel "reading level"@en-US ;
-    skosxl:preflabel alignment:label-readingLevel ;    
+    skosxl:preflabel alignment:label-readingLevel ;
     skos:definition "The point in the framework being referenced defines a level or range of reading ability expected for a person using the learning resource being described."@en-US ;
-    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#ReadingLevel."@en-US ;      
-    skos:inScheme alignment: ;     
-    vs:term_status "unstable" .              
+    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#ReadingLevel."@en-US ;
+    skos:inScheme alignment: ;
+    vs:term_status "unstable" .
 
 alignment:teaches a skos:Concept ;
     skos:prefLabel "teaches"@en-US ;
-    skosxl:preflabel alignment:label-teaches ;    
+    skosxl:preflabel alignment:label-teaches ;
     skos:definition "The learning resource being described may be used to teach the competency being referenced."@en-US ;
-    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#Teaches."@en-US ;   
+    dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000869#Teaches."@en-US ;
     skos:inScheme alignment: ;
-    vs:term_status "unstable" .                          
+    vs:term_status "unstable" .
     
-#============================= 
+#=============================
 # EXTENDED LABELS
-#=============================    
+#=============================
     
 alignment:label-assesses a skosxl:label ;
     skosxl:literalForm "assesses"@en-US .
@@ -87,17 +87,16 @@ alignment:label-complexityLevel a skosxl:label ;
     skosxl:literalForm "complexity level"@en-US . 
     
 alignment:label-educationalLevel a skosxl:label ;
-    skosxl:literalForm "educational level"@en-US .    
+    skosxl:literalForm "educational level"@en-US .
     
 alignment:label-educationalSubject a skosxl:label ;
     skosxl:literalForm "educational subject"@en-US .
     
 alignment:label-prerequisite a skosxl:label ;
-    skosxl:literalForm "prerequisite"@en-US .            
+    skosxl:literalForm "prerequisite"@en-US .
     
 alignment:label-readingLevel a skosxl:label ;
-    skosxl:literalForm "reading level"@en-US .       
+    skosxl:literalForm "reading level"@en-US .
     
 alignment:label-teaches a skosxl:label ;
-    skosxl:literalForm "teaches"@en-US .      
-                                    
+    skosxl:literalForm "teaches"@en-US .

--- a/interactivityType.ttl
+++ b/interactivityType.ttl
@@ -12,28 +12,28 @@
 @prefix bibo: <http://purl.org/ontology/bibo/status/> .
 
 interactivity: a skos:ConceptScheme ;
-    dc:title "Interactivity Type Vocabulary"@en-US ;
-    dc:creator "LRMI Task Group (DCMI)"@en-US ;    
+    dc:title "LRMI Interactivity Type Vocabulary"@en-US ;
+    dc:creator "LRMI Task Group (DCMI)"@en-US ;
     dcterms:description "A concept scheme that defines the predominate interactivity mode of the learning resource being described."@en-US ;
     dcterms:source "Based on the IEEE Learning Object Metadata standard (IEEE/LOM - IEEE 1484.12.1-202)."@en-US ;
-    dcterms:dateSubmitted "2015-01-21"^^xsd:date ;    
-    adms:status bibo:draft ;       
+    dcterms:dateSubmitted "2015-01-21"^^xsd:date ;
+    adms:status bibo:draft ;
     dcterms:license <http://creativecommons.org/licenses/by/4.0/> .
 
 interactivity:active a skos:Concept ;
     skos:prefLabel "active"@en-US ;
-    skosxl:preflabel interactivity:label-active ;   
+    skosxl:preflabel interactivity:label-active ;
     skos:definition "Learning that engages and challenges the learner's thinking using real-life and imaginary situations taking advantage of the opportunities for learning presented by investigating, exploring, events, and life experiences."@en-US ;
     dcterms:source "Based on the IEEE Learning Object Metadata standard (IEEE 1484.12.1-202 (LOMv1.0))."@en-US ;
     skos:inScheme interactivity: ;
     vs:term_status "unstable" .
-    
+
 interactivity:expositive a skos:Concept ;
     skos:prefLabel "expositive"@en-US ;
-    skosxl:preflabel interactivity:label-expositive ;  
+    skosxl:preflabel interactivity:label-expositive ;
     skos:definition "Use of a subject-matter expert to explain a concept or give clear and concise information in a purposeful way to the passive learner."@en-US ;
     dcterms:source "Based on the IEEE Learning Object Metadata standard (IEEE 1484.12.1-202 (LOMv1.0))."@en-US ;
-    skos:inScheme interactivity: ;    
+    skos:inScheme interactivity: ;
     vs:term_status "unstable" .
     
 interactivity:mixed a skos:Concept ;
@@ -41,18 +41,18 @@ interactivity:mixed a skos:Concept ;
     skosxl:preflabel interactivity:label-mixed ;
     skos:definition "Instructional interactions comprised of a mix of active learning and expositive approaches."@en-US ;
     dcterms:source "Based on IEEE Learning Object Metadata standard (IEEE 1484.12.1-202 (LOMv1.0))."@en-US ;
-    skos:inScheme interactivity: ;    
+    skos:inScheme interactivity: ;
     vs:term_status "unstable" .
     
-#============================= 
+#=============================
 # EXTENDED LABELS
-#=============================     
-    
+#=============================
+
 interactivity:label-active a skosxl:label ;
     skosxl:literalForm "active"@en-US . 
-    
+
 interactivity:label-expositive a skosxl:label ;
     skosxl:literalForm "expositive"@en-US .
-    
+
 interactivity:label-mixed a skosxl:label ;
     skosxl:literalForm "mixed"@en-US . 

--- a/learningResourceType.ttl
+++ b/learningResourceType.ttl
@@ -22,12 +22,12 @@ resourceType: a skos:ConceptScheme ;
 
 resourceType:alternateAssessment a skos:Concept ;
     skos:prefLabel "alternate assessment"@en-US ;
-    skosxl:prefLabel resourceType:label-alternateAssessment ;    
+    skosxl:prefLabel resourceType:label-alternateAssessment ;
     skos:definition "An assessment that is used to evaluate the performance of students who are unable to participate in general assessments even with accommodations."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000928#AlternateAssessment"@en-US ;
-    vs:term_status "unstable" .   
-    
+    vs:term_status "unstable" .
+
 resourceType:assessmentItem a skos:Concept ;
     skos:prefLabel "assessment item"@en-US ;
     skosxl:prefLabel resourceType:label-assessmentItem ; 
@@ -35,10 +35,10 @@ resourceType:assessmentItem a skos:Concept ;
     skos:inScheme resourceType: ;
     dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000928#AssessmentItem"@en-US ;
     vs:term_status "unstable" .
-       
+
 resourceType:course a skos:Concept ;
     skos:prefLabel "course"@en-US ;
-    skosxl:prefLabel resourceType:label-course ; 
+    skosxl:prefLabel resourceType:label-course ;
     skos:definition "A series of units and lessons used to teach the skills and knowledge required by its curriculum."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000928#Course"@en-us ;
@@ -51,7 +51,7 @@ resourceType:demonstration-simulation a skos:Concept ;
     skos:inScheme resourceType: ;
     dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000928#DemonstrationSimulation"@en-US ;
     vs:term_status "unstable" .
-    
+
 resourceType:educatorCurriculumGuide a skos:Concept ;
     skos:prefLabel "educator curriculum guide"@en-US ;
     skosxl:prefLabel resourceType:label-educatorCurriculum ;
@@ -59,7 +59,7 @@ resourceType:educatorCurriculumGuide a skos:Concept ;
     skos:inScheme resourceType: ;
     dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000928#EducatorCurriculumGuide"@en-US ;
     vs:term_status "unstable" .
-    
+
 resourceType:formativeAssessment a skos:Concept ;
     skos:prefLabel "formative assessment"@en-US ;
     skosxl:prefLabel resourceType:label-formativeAssessment ;
@@ -83,7 +83,7 @@ resourceType:interim-summativeAssessment a skos:Concept ;
     skos:note "A learning resource of this type may be an \"assessment form,\" i.e. one instance of the assessment instrument that can equate scores with another instance of the same assessment."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000928#InterimSummativeAssessment"@en-US ;
-    vs:term_status "unstable" .    
+    vs:term_status "unstable" .
 
 resourceType:learningActivity a skos:Concept ;
     skos:prefLabel "learning activity"@en-US ;
@@ -91,15 +91,15 @@ resourceType:learningActivity a skos:Concept ;
     skos:definition "Activities engaged in by the learner for the purpose of acquiring certain skills, concepts, or knowledge, whether guided by an instructor or not. A Lesson may define one or more learning activities."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000928#LearningActivity"@en-US ;
-    vs:term_status "unstable" .    
+    vs:term_status "unstable" .
 
 resourceType:lesson a skos:Concept ;
     skos:prefLabel "lesson"@en-US ;
     skosxl:prefLabel resourceType:label-lesson ;
-    skos:definition "A detailed description of the course of instruction for a short period of time that is used by a teacher to guide class instruction.  A unit contains one or more lessons."@en-US ;
+    skos:definition "A detailed description of the course of instruction for a short period of time that is used by a teacher to guide class instruction. A unit contains one or more lessons."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000928#Lesson"@en-US ;
-    vs:term_status "unstable" .    
+    vs:term_status "unstable" .
 
 resourceType:primarySource a skos:Concept ;
     skos:prefLabel "primary source"@en-US ;
@@ -107,7 +107,7 @@ resourceType:primarySource a skos:Concept ;
     skos:definition "An artifact, document, recording, or other source of information that was created at the time under study and provides first-hand testimony or direct evidence concerning a topic under investigation."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000928#PrimarySource"@en-US ;
-    vs:term_status "unstable" .         
+    vs:term_status "unstable" .
 
 resourceType:rubricScoringGuide a skos:Concept ;
     skos:prefLabel "rubric scoring guide"@en-US ;
@@ -139,7 +139,7 @@ resourceType:textbook a skos:Concept ;
     skos:definition "A book used as a standard source of information on a particular subject."@en-US ;
     skos:inScheme resourceType: ;
     dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000928#Textbook"@en-US ;
-    vs:term_status "unstable" .       
+    vs:term_status "unstable" .
  
 resourceType:unit a skos:Concept ;
     skos:prefLabel "unit"@en-US ;
@@ -149,54 +149,54 @@ resourceType:unit a skos:Concept ;
     dcterms:source "Based on Common Education Data Standards (CEDS): https://ceds.ed.gov/element/000928#Unit"@en-US ;
     vs:term_status "unstable" .
     
-#============================= 
+#=============================
 # EXTENDED LABELS
-#=============================    
-    
+#=============================
+
 resourceType:label-alternateAssessment a skosxl:label ;
     skosxl:literalForm "alternate assessment"@en-US .
-        
+
 resourceType:label-assessmentItem a skosxl:label ;
     skosxl:literalForm "assessment item"@en-US . 
-        
+
 resourceType:label-course a skosxl:label ;
     skosxl:literalForm "course"@en-US .
-         
+
 resourceType:label-demonstration-simulation a skosxl:label ;
     skosxl:literalForm "demonstration/simulation"@en-US .
-         
+
 resourceType:label-educatorCurriculumGuide a skosxl:label ;
     skosxl:literalForm "educator curriculum"@en-US .
-         
+
 resourceType:label-formativeAssessment a skosxl:label ;
     skosxl:literalForm "formative assessment"@en-US .
-         
+
 resourceType:label-images-visuals a skosxl:label ;
     skosxl:literalForm "images/visuals"@en-US .
-         
+
 resourceType:label-interim-summativeAssessment a skosxl:label ;
     skosxl:literalForm "interim/summative assessment"@en-US .
-         
+
 resourceType:label-learningActivity a skosxl:label ;
     skosxl:literalForm "learning activity"@en-US .
-         
+
 resourceType:label-lesson a skosxl:label ;
     skosxl:literalForm "lesson"@en-US .
-         
+
 resourceType:label-primarySource a skosxl:label ;
     skosxl:literalForm "primary source"@en-US .
-         
+
 resourceType:label-rubricScoringGuide a skosxl:label ;
     skosxl:literalForm "rubric scoring guide"@en-US .
-         
+
 resourceType:label-selfAssessment a skosxl:label ;
     skosxl:literalForm "self assessment"@en-US .
-         
+
 resourceType:label-text a skosxl:label ;
     skosxl:literalForm "text"@en-US .
-         
+
 resourceType:label-textbook a skosxl:label ;
     skosxl:literalForm "textbook"@en-US .
-         
+
 resourceType:label-unit a skosxl:label ;
-    skosxl:literalForm "unit"@en-US .      
+    skosxl:literalForm "unit"@en-US .


### PR DESCRIPTION
Removing some double and trailing spaces and added an LRMI to one vocab title where it was missing.